### PR TITLE
Update project.clj to clojure 1.6.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject ants "0.1"
-    :dependencies [[org.clojure/clojure "1.1.0"]
-                 [org.clojure/clojure-contrib "1.1.0"]]
+    :dependencies [[org.clojure/clojure "1.6.0"]]
     :main demo.AntsAppletRunner)
     


### PR DESCRIPTION
Clojure 1.1.0 doesn't exist anymore, with clojure 1.6.0, clojure-contrib doesn't seem to exist.  Program runs fine without it.
